### PR TITLE
GitHub actions, status badges, community links

### DIFF
--- a/.github/workflows/homey-app-validate.yml
+++ b/.github/workflows/homey-app-validate.yml
@@ -12,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: athombv/github-action-homey-app-validate@master
+
+      - uses: actions/setup-node@v3
         with:
-          level: verified
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --audit=false
+
+      - name: Install Homey CLI
+        run: npm -g install homey
+
+      - name: App needs to pass verified level validation
+        run: homey app validate --level=verified
+        

--- a/.github/workflows/homey-app-validate.yml
+++ b/.github/workflows/homey-app-validate.yml
@@ -1,0 +1,17 @@
+name: Validate Homey App
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  main:
+    name: Validate Homey App
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: athombv/github-action-homey-app-validate@master
+        with:
+          level: verified

--- a/.github/workflows/homey-build-release.yml
+++ b/.github/workflows/homey-build-release.yml
@@ -1,0 +1,55 @@
+name: Build release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        description: Version
+        required: true
+        default: patch
+        options:
+          - major
+          - minor
+          - patch
+      changelog:
+        type: string
+        description: Changelog
+        required: true
+
+jobs:
+  main:
+    name: Build Homey release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update app version
+        uses: athombv/github-action-homey-app-version@master
+        id: update_app_version
+        with:
+          version: ${{ inputs.version }}
+          changelog: ${{ inputs.changelog }}
+
+      - name: Commit and push generated version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update Homey App Version to v${{ steps.update_app_version.outputs.version }}
+          tagging_message: v${{ steps.update_app_version.outputs.version }}
+
+      - name: Publish app
+        uses: athombv/github-action-homey-app-publish@master
+        id: publish
+        with:
+          personal_access_token: ${{ secrets.HOMEY_PAT }}
+
+      - name: Add manage URL to job summary
+        run: |
+          echo "App release to be managed at ${{ steps.publish.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+          
+      - name: Generate Github Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ inputs.changelog }}
+          generate_release_notes: true
+          make_latest: true
+          tag_name: v${{ steps.update_app_version.outputs.version }}

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -47,5 +47,6 @@
   "dependencies": {
     "net": "*"
   },
-  "homepage": "https://www.zaptec.com/"
+  "homepage": "https://www.zaptec.com/",
+  "homeyCommunityTopicId": "118631"
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -48,5 +48,5 @@
     "net": "*"
   },
   "homepage": "https://www.zaptec.com/",
-  "homeyCommunityTopicId": "118631"
+  "homeyCommunityTopicId": 118631
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -36,6 +36,7 @@
       }
     ]
   },
+  "support": "https://github.com/patricke94/com.zaptec/issues",
   "contributing": {
     "donate": {
       "paypal": {

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Homey validate the code automatically when pushing to the main branch.
 
 To use the github action for versioning, tagging, changelog and publishing, one need to aquire a personal access token (PAT) from [Developer portal](https://tools.developer.homey.app/me) and save it as a secret in your repository named `HOMEY_PAT`.
 
+## Links
+[Homey App](https://homey.app/a/com.zaptec)  
+[Homey Community](https://community.homey.app/t/app-pro-zaptec-charging/118631)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Zaptec
 [![Validate Homey App](https://github.com/PatrickE94/com.zaptec/actions/workflows/homey-app-validate.yml/badge.svg)](https://github.com/PatrickE94/com.zaptec/actions/workflows/homey-app-validate.yml)
+[![Build Homey App](https://github.com/PatrickE94/com.zaptec/actions/workflows/homey-build-release.yml/badge.svg)](https://github.com/PatrickE94/com.zaptec/actions/workflows/homey-build-release.yml)
 
 Adds support for Zaptec charging products.
+
+## Github actions
+Homey validate the code automatically when pushing to the main branch.
+
+To use the github action for versioning, tagging, changelog and publishing, one need to aquire a personal access token (PAT) from [Developer portal](https://tools.developer.homey.app/me) and save it as a secret in your repository named `HOMEY_PAT`.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Zaptec
+[![Validate Homey App](https://github.com/PatrickE94/com.zaptec/actions/workflows/homey-app-validate.yml/badge.svg)](https://github.com/PatrickE94/com.zaptec/actions/workflows/homey-app-validate.yml)
 
 Adds support for Zaptec charging products.

--- a/app.json
+++ b/app.json
@@ -37,6 +37,7 @@
       }
     ]
   },
+  "support": "https://github.com/patricke94/com.zaptec/issues",
   "contributing": {
     "donate": {
       "paypal": {

--- a/app.json
+++ b/app.json
@@ -49,7 +49,7 @@
     "net": "*"
   },
   "homepage": "https://www.zaptec.com/",
-  "homeyCommunityTopicId": "118631",
+  "homeyCommunityTopicId": 118631,
   "flow": {
     "triggers": [
       {

--- a/app.json
+++ b/app.json
@@ -49,6 +49,7 @@
     "net": "*"
   },
   "homepage": "https://www.zaptec.com/",
+  "homeyCommunityTopicId": "118631",
   "flow": {
     "triggers": [
       {


### PR DESCRIPTION
1.  Added GitHub action for:

- Validation `homey app validate --level=verified`
- Versioning, changelog and publish

The first one runs automatically on push to *main*
The publish-one requires a secret to be created. See the readme for details.

2.  Added status badges for the actions in the readme, for easy error catching.
3. Added links to community topic (created a new one, already got a comment on temperature readings)
4. Added a support tag to manifest (validation marked it as required)