### PR TITLE
Fix home driver flow cards

### DIFF
--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -10,7 +10,7 @@ import {
 } from '../../lib/zaptec';
 import { ChargerStateModel } from '../../lib/zaptec/models';
 
-export class ProCharger extends Homey.Device {
+export class HomeCharger extends Homey.Device {
   private debugLog: string[] = [];
   private cronTasks: cron.ScheduledTask[] = [];
   private api?: ZaptecApi;
@@ -20,7 +20,7 @@ export class ProCharger extends Homey.Device {
    * onInit is called when the device is initialized.
    */
   async onInit() {
-    this.log('ProCharger is initializing');
+    this.log('HomeCharger is initializing');
     this.api = new ZaptecApi();
     this.renewToken();
 
@@ -41,7 +41,7 @@ export class ProCharger extends Homey.Device {
     // Do initial slow poll at start, we don't know how long ago we read it out.
     this.pollSlowValues();
 
-    this.log('ProCharger has been initialized');
+    this.log('HomeCharger has been initialized');
   }
 
   /**
@@ -79,7 +79,7 @@ export class ProCharger extends Homey.Device {
    * onAdded is called when the user adds the device, called just after pairing.
    */
   async onAdded() {
-    this.log('ProCharger has been added');
+    this.log('HomeCharger has been added');
     // Trigger initial polls to make it look nice immediately!
     this.pollValues();
     this.pollSlowValues();
@@ -98,7 +98,7 @@ export class ProCharger extends Homey.Device {
     newSettings: { [key: string]: string };
     changedKeys: string[];
   }): Promise<string | void> {
-    this.log('ProCharger settings where changed: ', JSON.stringify(changes));
+    this.log('HomeCharger settings where changed: ', JSON.stringify(changes));
 
     // Allow user to select if they want phase voltage as a capability or not.
     if (changes.changedKeys.some((k) => k === 'showVoltage')) {
@@ -120,14 +120,14 @@ export class ProCharger extends Homey.Device {
    * @param {string} name The new name
    */
   async onRenamed(name: string) {
-    this.log(`ProCharger ${this.getName()} was renamed to ${name}`);
+    this.log(`HomeCharger ${this.getName()} was renamed to ${name}`);
   }
 
   /**
    * onDeleted is called when the user deleted the device.
    */
   async onDeleted() {
-    this.log('ProCharger has been deleted');
+    this.log('HomeCharger has been deleted');
     for (const task of this.cronTasks) task.stop();
   }
 
@@ -427,28 +427,28 @@ export class ProCharger extends Homey.Device {
     // Entering charging state => Charging starts
     if (newMode === ChargerOperationMode.Connected_Charging) {
       await this.homey.flow
-        .getDeviceTriggerCard('pro_charging_starts')
+        .getDeviceTriggerCard('home_charging_starts')
         .trigger(this, tokens);
     }
 
     // Changed from charging state => Charging stops
     if (previousMode === ChargerOperationMode.Connected_Charging) {
       await this.homey.flow
-        .getDeviceTriggerCard('pro_charging_stops')
+        .getDeviceTriggerCard('home_charging_stops')
         .trigger(this, tokens);
     }
 
     // Was disconnected and now becomes connected => Car connected
     if (newModeConnected && previouslyDisconnected) {
       await this.homey.flow
-        .getDeviceTriggerCard('pro_car_connects')
+        .getDeviceTriggerCard('home_car_connects')
         .trigger(this, tokens);
     }
 
     // Was connected and now becomes disconnected => Car disconnected
     if (!newModeConnected && !previouslyDisconnected) {
       await this.homey.flow
-        .getDeviceTriggerCard('pro_car_disconnects')
+        .getDeviceTriggerCard('home_car_disconnects')
         .trigger(this, tokens);
     }
   }
@@ -563,4 +563,4 @@ export class ProCharger extends Homey.Device {
   }
 }
 
-module.exports = ProCharger;
+module.exports = HomeCharger;

--- a/drivers/home/driver.spec.ts
+++ b/drivers/home/driver.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-describe('Go driver', () => {
+describe('Home driver', () => {
   it('should do a test', () => {
     assert(true);
   });

--- a/drivers/home/driver.ts
+++ b/drivers/home/driver.ts
@@ -1,12 +1,12 @@
 import Homey from 'homey';
 import { ChargerOperationMode, chargerOperationModeStr, ZaptecApi } from '../../lib/zaptec';
-import type { ProCharger } from './device';
+import type { HomeCharger } from './device';
 
 interface InstallationCurrentControlArgs {
   current1: number;
   current2: number;
   current3: number;
-  device: ProCharger;
+  device: HomeCharger;
 }
 
 class HomeDriver extends Homey.Driver {

--- a/drivers/pro/driver.spec.ts
+++ b/drivers/pro/driver.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-describe('Go driver', () => {
+describe('Pro driver', () => {
   it('should do a test', () => {
     assert(true);
   });


### PR DESCRIPTION
The trigger flow cards for Home driver had prefix 'pro' . I suspect change of charging state triggered the pro-cards instead of Home trigger-cards. Corrected.
Also correct Driver names and logging.