### PR TITLE
Handle unavailable installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 /.homeybuild/
 .DS_Store
+/.vscode/

--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -8,6 +8,7 @@ import {
   chargerOperationModeStr,
   chargerOperationModeFromStr,
 } from '../../lib/zaptec';
+import { ApiError } from '../../lib/zaptec/error';
 import { ChargerStateModel } from '../../lib/zaptec/models';
 
 export class GoCharger extends Homey.Device {
@@ -253,6 +254,18 @@ export class GoCharger extends Homey.Device {
     const year = new Date().getFullYear();
 
     this.api
+      .getInstallation(this.getData().installationId)
+      .then((installation) => {
+        if (installation.Id === this.getData().installationId && !this.hasCapability('available_installation_current'))
+          this.addCapability('available_installation_current');
+      })
+      .catch((e) => {
+        this.logToDebug(`Failed to poll installation: ${e}`);
+        if (this.hasCapability('available_installation_current')) 
+          this.removeCapability('available_installation_current');
+      });
+
+    this.api
       .getChargeHistory({
         ChargerId: this.getData().id,
         From: new Date(year, 0, 1, 0, 0, 1).toJSON(),
@@ -398,10 +411,12 @@ export class GoCharger extends Homey.Device {
    * Poll the available current for the installation.
    */
   protected async pollAvailableCurrent() {
-    if (this.api === undefined) return;
+    if (this.api === undefined || !this.hasCapability('available_installation_current')) return;
     const info = await this.api
       .getInstallation(this.getData().installationId)
-      .catch((e) => {
+      .catch((e) => {     
+        if (e instanceof ApiError && e.message.indexOf('Unknown object') >= 0 && this.hasCapability('available_installation_current'))
+          this.removeCapability('available_installation_current'); 
         this.logToDebug(
           `Failed to get installation info when updating available current: ${e}`,
         );

--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -489,7 +489,7 @@ export class GoCharger extends Homey.Device {
     const tokens = {
       charging: newMode === ChargerOperationMode.Connected_Charging,
       car_connected: newModeConnected,
-      current_limit: this.getCapabilityValue('available_installation_current'),
+      current_limit: Number(this.getCapabilityValue('available_installation_current')),
     };
 
     // Entering charging state => Charging starts

--- a/drivers/go/driver.ts
+++ b/drivers/go/driver.ts
@@ -35,7 +35,9 @@ class GoDriver extends Homey.Driver {
           );
           this.log(
             `[${device.getName()}] - current: '${current1}/${current2}/${current3}' amps`,
-          );
+          );          
+          if( !device.hasCapability('available_installation_current'))
+            throw new Error('Device does not support setting available current, because of missing access to the installation');
 
           return device.setInstallationAvailableCurrent(
             current1,

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -8,6 +8,7 @@ import {
   chargerOperationModeStr,
   chargerOperationModeFromStr,
 } from '../../lib/zaptec';
+import { ApiError } from '../../lib/zaptec/error';
 import { ChargerStateModel } from '../../lib/zaptec/models';
 
 export class HomeCharger extends Homey.Device {
@@ -242,6 +243,18 @@ export class HomeCharger extends Homey.Device {
     const year = new Date().getFullYear();
 
     this.api
+      .getInstallation(this.getData().installationId)
+      .then((installation) => {
+        if (installation.Id === this.getData().installationId && !this.hasCapability('available_installation_current'))
+          this.addCapability('available_installation_current');
+      })
+      .catch((e) => {
+        this.logToDebug(`Failed to poll installation: ${e}`);
+        if (this.hasCapability('available_installation_current')) 
+          this.removeCapability('available_installation_current');
+      });
+
+    this.api
       .getChargeHistory({
         ChargerId: this.getData().id,
         From: new Date(year, 0, 1, 0, 0, 1).toJSON(),
@@ -387,10 +400,12 @@ export class HomeCharger extends Homey.Device {
    * Poll the available current for the installation.
    */
   protected async pollAvailableCurrent() {
-    if (this.api === undefined) return;
+    if (this.api === undefined || !this.hasCapability('available_installation_current')) return;
     const info = await this.api
       .getInstallation(this.getData().installationId)
-      .catch((e) => {
+      .catch((e) => {     
+        if (e instanceof ApiError && e.message.indexOf('Unknown object') >= 0 && this.hasCapability('available_installation_current'))
+          this.removeCapability('available_installation_current');
         this.logToDebug(
           `Failed to get installation info when updating available current: ${e}`,
         );

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -478,7 +478,7 @@ export class HomeCharger extends Homey.Device {
     const tokens = {
       charging: newMode === ChargerOperationMode.Connected_Charging,
       car_connected: newModeConnected,
-      current_limit: this.getCapabilityValue('available_installation_current'),
+      current_limit: Number(this.getCapabilityValue('available_installation_current')),
     };
 
     // Entering charging state => Charging starts

--- a/drivers/home/driver.ts
+++ b/drivers/home/driver.ts
@@ -36,6 +36,8 @@ class HomeDriver extends Homey.Driver {
           this.log(
             `[${device.getName()}] - current: '${current1}/${current2}/${current3}' amps`,
           );
+          if( !device.hasCapability('available_installation_current'))
+            throw new Error('Device does not support setting available current, because of missing access to the installation');
 
           return device.setInstallationAvailableCurrent(
             current1,

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -8,6 +8,7 @@ import {
   chargerOperationModeStr,
   chargerOperationModeFromStr,
 } from '../../lib/zaptec';
+import { ApiError } from '../../lib/zaptec/error';
 import { ChargerStateModel } from '../../lib/zaptec/models';
 
 export class ProCharger extends Homey.Device {
@@ -244,6 +245,18 @@ export class ProCharger extends Homey.Device {
     const year = new Date().getFullYear();
 
     this.api
+      .getInstallation(this.getData().installationId)
+      .then((installation) => {
+        if (installation.Id === this.getData().installationId && !this.hasCapability('available_installation_current'))
+          this.addCapability('available_installation_current');
+      })
+      .catch((e) => {
+        this.logToDebug(`Failed to poll installation: ${e}`);
+        if (this.hasCapability('available_installation_current')) 
+          this.removeCapability('available_installation_current');
+      });
+
+    this.api
       .getChargeHistory({
         ChargerId: this.getData().id,
         From: new Date(year, 0, 1, 0, 0, 1).toJSON(),
@@ -389,10 +402,12 @@ export class ProCharger extends Homey.Device {
    * Poll the available current for the installation.
    */
   protected async pollAvailableCurrent() {
-    if (this.api === undefined) return;
+    if (this.api === undefined || !this.hasCapability('available_installation_current')) return;
     const info = await this.api
       .getInstallation(this.getData().installationId)
-      .catch((e) => {
+      .catch((e) => {     
+        if (e instanceof ApiError && e.message.indexOf('Unknown object') >= 0 && this.hasCapability('available_installation_current'))
+          this.removeCapability('available_installation_current');
         this.logToDebug(
           `Failed to get installation info when updating available current: ${e}`,
         );

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -481,7 +481,7 @@ export class ProCharger extends Homey.Device {
     const tokens = {
       charging: newMode === ChargerOperationMode.Connected_Charging,
       car_connected: newModeConnected,
-      current_limit: this.getCapabilityValue('available_installation_current'),
+      current_limit: Number(this.getCapabilityValue('available_installation_current')),
     };
 
     // Entering charging state => Charging starts

--- a/drivers/pro/driver.ts
+++ b/drivers/pro/driver.ts
@@ -36,6 +36,8 @@ class ProDriver extends Homey.Driver {
           this.log(
             `[${device.getName()}] - current: '${current1}/${current2}/${current3}' amps`,
           );
+          if( !device.hasCapability('available_installation_current'))
+            throw new Error('Device does not support setting available current, because of missing access to the installation');
 
           return device.setInstallationAvailableCurrent(
             current1,


### PR DESCRIPTION
On some occasions the charger is part of a larger grid installation that is controlled by another account. In for instance a [Condominium](https://en.wikipedia.org/wiki/Condominium).
Therefore the given installation id on the charger is not available. As a consequence the available current is not available. And the action card "Set available current to" will also fail.

I added a check on pollSlowValues() if the installation is available. If not, removes the capability "Current limit" (available_installation_current). But adds it again if available.

Also added check if this capability exists on the device, on all the methods that uses the /installation/ endpoint.

Found this to be the best solution