### PR TITLE
feat(api): add jitter to cron jobs, paging support, and backoff handling

### DIFF
--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -21,7 +21,8 @@ export class GoCharger extends Homey.Device {
    */
   async onInit() {
     this.log('GoCharger is initializing');
-    this.api = new ZaptecApi();
+    const appVersion = this.homey.app.manifest.version;
+    this.api = new ZaptecApi(appVersion);
     this.renewToken();
 
     await this.api.authenticate(
@@ -36,7 +37,13 @@ export class GoCharger extends Homey.Device {
     this.cronTasks.push(
       cron.schedule('0,30 * * * * *', () => this.pollValues()),
       cron.schedule('59 * * * * *', () => this.updateDebugLog()),
-      cron.schedule('0 0 7 * * * *', () => this.pollSlowValues()),
+      cron.schedule('0 0 7 * * * *', () => {
+        // Random delay between 0 and 120 seconds
+        const jitter = Math.floor(Math.random() * 120000);
+        setTimeout(() => {
+          this.pollSlowValues();
+        }, jitter);
+      }),
     );
 
     // Do initial slow poll at start, we don't know how long ago we read it out.
@@ -45,28 +52,29 @@ export class GoCharger extends Homey.Device {
     this.log('GoCharger has been initialized');
   }
 
-      /**
+  /**
    * Migrate settings from the old settings format to the new one.
    * If the deviceid setting is empty, poll the charger info and store the device id.
    */
-      private async migrateSettings() {
-        if (this.api === undefined) return;
-    
-        if (this.getSetting('deviceid') === ""){
-          await this.api.getCharger(this.getData().id)
-          .then((charger) => {    
-            this.setSettings({
-              deviceid: charger.DeviceId,
-            });
-          })
-          .then(() => {
-            this.logToDebug(`Got charger info - added device id`);
-          })
-          .catch((e) => {
-            this.logToDebug(`Failed to poll charger info: ${e}`);
+  private async migrateSettings() {
+    if (this.api === undefined) return;
+
+    if (this.getSetting('deviceid') === '') {
+      await this.api
+        .getCharger(this.getData().id)
+        .then((charger) => {
+          this.setSettings({
+            deviceid: charger.DeviceId,
           });
-        }
-      }
+        })
+        .then(() => {
+          this.logToDebug(`Got charger info - added device id`);
+        })
+        .catch((e) => {
+          this.logToDebug(`Failed to poll charger info: ${e}`);
+        });
+    }
+  }
 
   /**
    * Verify all expected capabilities and apply changes to capabilities.
@@ -257,11 +265,11 @@ export class GoCharger extends Homey.Device {
         ChargerId: this.getData().id,
         From: new Date(year, 0, 1, 0, 0, 1).toJSON(),
         DetailLevel: 0,
-        PageSize: 5000,
+        PageSize: 50,
       })
       .then((charges) => {
         const yearlyEnergy =
-          charges.Data?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
+          charges?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
         return this.setCapabilityValue('meter_power.this_year', yearlyEnergy);
       })
       .then(() => {
@@ -371,10 +379,10 @@ export class GoCharger extends Homey.Device {
         break;
 
       case ApolloDeviceObservation.SmartComputerSoftwareApplicationVersion:
-          await this.setSettings({
-            firmware: state.ValueAsString,
-          });
-          break;
+        await this.setSettings({
+          firmware: state.ValueAsString,
+        });
+        break;
 
       // The data for the previous session is JSON stringified into this state
       // variable
@@ -524,7 +532,10 @@ export class GoCharger extends Homey.Device {
         SignedSession: string;
       } = JSON.parse(data);
 
-      await this.setCapabilityValue('meter_power.last_session', Number(session.Energy));
+      await this.setCapabilityValue(
+        'meter_power.last_session',
+        Number(session.Energy),
+      );
     } catch (e) {
       this.logToDebug(`onLastSession fail: ${e}`);
     }

--- a/drivers/go/driver.ts
+++ b/drivers/go/driver.ts
@@ -1,5 +1,9 @@
 import Homey from 'homey';
-import { ChargerOperationMode, chargerOperationModeStr, ZaptecApi } from '../../lib/zaptec';
+import {
+  ChargerOperationMode,
+  chargerOperationModeStr,
+  ZaptecApi,
+} from '../../lib/zaptec';
 import type { GoCharger } from './device';
 
 interface InstallationCurrentControlArgs {
@@ -73,19 +77,27 @@ class GoDriver extends Homey.Driver {
     this.homey.flow
       .getActionCard('stop_charging')
       .registerRunListener(async ({ device }) => device.stopCharging());
-    
+
     this.homey.flow
       .getActionCard('go_cable_permanent_lock')
-      .registerRunListener(async ({ device }) => device.lockCable(true).then(() => device.setCapabilityValue('cable_permanent_lock', true)));
-      
+      .registerRunListener(async ({ device }) =>
+        device
+          .lockCable(true)
+          .then(() => device.setCapabilityValue('cable_permanent_lock', true)),
+      );
+
     this.homey.flow
       .getActionCard('go_cable_permanent_open')
-      .registerRunListener(async ({ device }) => device.lockCable(false).then(() => device.setCapabilityValue('cable_permanent_lock', false)));
-
+      .registerRunListener(async ({ device }) =>
+        device
+          .lockCable(false)
+          .then(() => device.setCapabilityValue('cable_permanent_lock', false)),
+      );
   }
 
   async onPair(session: Homey.Driver.PairSession) {
-    const api = new ZaptecApi();
+    const appVersion = this.homey.app.manifest.version;
+    const api = new ZaptecApi(appVersion);
     let username = '';
     let password = '';
 
@@ -94,11 +106,13 @@ class GoDriver extends Homey.Driver {
       async (data: { username: string; password: string }) => {
         username = data.username;
         password = data.password;
+        this.log("Trying to authenticate with Zaptec's API");
 
         try {
           await api.authenticate(username, password);
           return true;
         } catch (_error) {
+          this.log("Failed to authenticate with Zaptec's API. Error:", _error);
           return false;
         }
       },

--- a/drivers/home/driver.ts
+++ b/drivers/home/driver.ts
@@ -1,5 +1,9 @@
 import Homey from 'homey';
-import { ChargerOperationMode, chargerOperationModeStr, ZaptecApi } from '../../lib/zaptec';
+import {
+  ChargerOperationMode,
+  chargerOperationModeStr,
+  ZaptecApi,
+} from '../../lib/zaptec';
 import type { HomeCharger } from './device';
 
 interface InstallationCurrentControlArgs {
@@ -76,16 +80,24 @@ class HomeDriver extends Homey.Driver {
 
     this.homey.flow
       .getActionCard('home_cable_permanent_lock')
-      .registerRunListener(async ({ device }) => device.lockCable(true).then(() => device.setCapabilityValue('cable_permanent_lock', true)));
-      
+      .registerRunListener(async ({ device }) =>
+        device
+          .lockCable(true)
+          .then(() => device.setCapabilityValue('cable_permanent_lock', true)),
+      );
+
     this.homey.flow
       .getActionCard('home_cable_permanent_open')
-      .registerRunListener(async ({ device }) => device.lockCable(false).then(() => device.setCapabilityValue('cable_permanent_lock', false)));
-
+      .registerRunListener(async ({ device }) =>
+        device
+          .lockCable(false)
+          .then(() => device.setCapabilityValue('cable_permanent_lock', false)),
+      );
   }
 
   async onPair(session: Homey.Driver.PairSession) {
-    const api = new ZaptecApi();
+    const appVersion = this.homey.app.manifest.version;
+    const api = new ZaptecApi(appVersion);
     let username = '';
     let password = '';
 

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -21,7 +21,8 @@ export class ProCharger extends Homey.Device {
    */
   async onInit() {
     this.log('ProCharger is initializing');
-    this.api = new ZaptecApi();
+    const appVersion = this.homey.app.manifest.version;
+    this.api = new ZaptecApi(appVersion);
     this.renewToken();
 
     await this.api.authenticate(
@@ -36,7 +37,13 @@ export class ProCharger extends Homey.Device {
     this.cronTasks.push(
       cron.schedule('0,30 * * * * *', () => this.pollValues()),
       cron.schedule('59 * * * * *', () => this.updateDebugLog()),
-      cron.schedule('0 0 7 * * * *', () => this.pollSlowValues()),
+      cron.schedule('0 0 7 * * * *', () => {
+        // Random delay between 0 and 120 seconds
+        const jitter = Math.floor(Math.random() * 120000);
+        setTimeout(() => {
+          this.pollSlowValues();
+        }, jitter);
+      }),
     );
 
     // Do initial slow poll at start, we don't know how long ago we read it out.
@@ -52,19 +59,20 @@ export class ProCharger extends Homey.Device {
   private async migrateSettings() {
     if (this.api === undefined) return;
 
-    if (this.getSetting('deviceid') === ""){
-      await this.api.getCharger(this.getData().id)
-      .then((charger) => {    
-        this.setSettings({
-          deviceid: charger.DeviceId,
+    if (this.getSetting('deviceid') === '') {
+      await this.api
+        .getCharger(this.getData().id)
+        .then((charger) => {
+          this.setSettings({
+            deviceid: charger.DeviceId,
+          });
+        })
+        .then(() => {
+          this.logToDebug(`Got charger info - added device id`);
+        })
+        .catch((e) => {
+          this.logToDebug(`Failed to poll charger info: ${e}`);
         });
-      })
-      .then(() => {
-        this.logToDebug(`Got charger info - added device id`);
-      })
-      .catch((e) => {
-        this.logToDebug(`Failed to poll charger info: ${e}`);
-      });
     }
   }
 
@@ -74,8 +82,7 @@ export class ProCharger extends Homey.Device {
    * This avoids having to re-add the device when modifying capabilities.
    */
   private async migrateCapabilities() {
-    const remove: string[] = [
-    ];
+    const remove: string[] = [];
 
     for (const cap of remove)
       if (this.hasCapability(cap)) await this.removeCapability(cap);
@@ -103,7 +110,6 @@ export class ProCharger extends Homey.Device {
       if (value) await this.lockCable(true);
       else await this.lockCable(false);
     });
-
   }
 
   /**
@@ -248,11 +254,11 @@ export class ProCharger extends Homey.Device {
         ChargerId: this.getData().id,
         From: new Date(year, 0, 1, 0, 0, 1).toJSON(),
         DetailLevel: 0,
-        PageSize: 5000,
+        PageSize: 50,
       })
       .then((charges) => {
         const yearlyEnergy =
-          charges.Data?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
+          charges?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
         return this.setCapabilityValue('meter_power.this_year', yearlyEnergy);
       })
       .then(() => {
@@ -399,7 +405,6 @@ export class ProCharger extends Homey.Device {
         throw e;
       });
 
-
     const isNumber = (n: number | undefined | null): n is number =>
       n !== undefined && n !== null;
     const maxCurrent = isNumber(info.MaxCurrent) ? info.MaxCurrent : 40;
@@ -516,7 +521,10 @@ export class ProCharger extends Homey.Device {
         SignedSession: string;
       } = JSON.parse(data);
 
-      await this.setCapabilityValue('meter_power.last_session', Number(session.Energy));
+      await this.setCapabilityValue(
+        'meter_power.last_session',
+        Number(session.Energy),
+      );
     } catch (e) {
       this.logToDebug(`onLastSession fail: ${e}`);
     }

--- a/drivers/pro/driver.ts
+++ b/drivers/pro/driver.ts
@@ -1,5 +1,9 @@
 import Homey from 'homey';
-import { ChargerOperationMode, chargerOperationModeStr, ZaptecApi } from '../../lib/zaptec';
+import {
+  ChargerOperationMode,
+  chargerOperationModeStr,
+  ZaptecApi,
+} from '../../lib/zaptec';
 import type { ProCharger } from './device';
 
 interface InstallationCurrentControlArgs {
@@ -76,17 +80,24 @@ class ProDriver extends Homey.Driver {
 
     this.homey.flow
       .getActionCard('pro_cable_permanent_lock')
-      .registerRunListener(async ({ device }) => device.lockCable(true).then(() => device.setCapabilityValue('cable_permanent_lock', true)));
+      .registerRunListener(async ({ device }) =>
+        device
+          .lockCable(true)
+          .then(() => device.setCapabilityValue('cable_permanent_lock', true)),
+      );
 
     this.homey.flow
       .getActionCard('pro_cable_permanent_open')
-      .registerRunListener(async ({ device }) => device.lockCable(false).then(() => device.setCapabilityValue('cable_permanent_lock', false)));
-
-
+      .registerRunListener(async ({ device }) =>
+        device
+          .lockCable(false)
+          .then(() => device.setCapabilityValue('cable_permanent_lock', false)),
+      );
   }
 
   async onPair(session: Homey.Driver.PairSession) {
-    const api = new ZaptecApi();
+    const appVersion = this.homey.app.manifest.version;
+    const api = new ZaptecApi(appVersion);
     let username = '';
     let password = '';
 

--- a/lib/zaptec/api.spec.ts
+++ b/lib/zaptec/api.spec.ts
@@ -3,7 +3,7 @@ import { ZaptecApi } from './api';
 
 describe('Zaptec API Client', () => {
   it('should use token after authentication', async () => {
-    const api = new ZaptecApi();
+    const api = new ZaptecApi('1.0.0');
     nock('https://api.zaptec.com')
       .post('/oauth/token', 'grant_type=password&username=test&password=123')
       .reply(200, {

--- a/lib/zaptec/api.ts
+++ b/lib/zaptec/api.ts
@@ -73,10 +73,64 @@ async function request(
 }
 
 /**
+ * Perform a HTTP request against the Zaptec API and handle 429 responses with backoff
+ *
+ * This is a convenience function to promisify the HTTP API, alongside sane defaults.
+ *
+ * Assumes a 15s timeout is wanted.
+ *
+ * @param {string} path - URL path to endpoint
+ * @param {[http.RequestOptions]} options - Generic Node HTTP options to pass with request
+ * @param {[string]} data - Any data to write as the body of the request.
+ * @param {[number]} maxRetries - Maximum number of retries before giving up.
+ * @returns {Response<string>} A response object with the response body and HTTP message object.
+ */
+async function requestWithBackoff(
+  path: string,
+  options: https.RequestOptions,
+  data?: string,
+  maxRetries = 5,
+): Promise<Response<string>> {
+  let retries = 0;
+  let backoff = 500;
+
+  const delay = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+      setTimeout(() => resolve(), ms);
+    });
+
+  while (retries < maxRetries) {
+    const response = await request(path, options, data);
+
+    // If not a 429 response, return immediately
+    if (response.response.statusCode !== 429) return response;
+
+    // If retry after header is set, use that value
+    const retryAfter = response.response.headers['retry-after'];
+    if (retryAfter !== undefined && retryAfter) {
+      const retryAfterSeconds = Number(retryAfter);
+      if (!Number.isNaN(retryAfterSeconds)) backoff = retryAfterSeconds * 1000;
+    }
+
+    // Wait and increase backoff time
+    await delay(backoff);
+    backoff *= 2; // Exponential backoff
+    retries += 1;
+  }
+
+  throw new Error(`Max retries exceeded for path: ${path}`);
+}
+
+/**
  * Simple HTTP wrapper around the Zaptec API
  */
 export class ZaptecApi {
+  private version: string;
   protected bearerToken?: string;
+
+  constructor(version: string) {
+    this.version = version;
+  }
 
   protected async get<T>(
     path: string,
@@ -84,12 +138,13 @@ export class ZaptecApi {
   ): Promise<Response<T>> {
     const headers: Record<string, string> = {
       Accept: 'application/json',
+      'User-Agent': this.getUserAgent(),
     };
 
     if (this.bearerToken !== undefined)
       headers.Authorization = `Bearer ${this.bearerToken}`;
 
-    const response = await request(path, {
+    const response = await requestWithBackoff(path, {
       method: 'GET',
       headers,
       ...options,
@@ -126,12 +181,13 @@ export class ZaptecApi {
           ? 'application/json'
           : 'application/x-www-form-urlencoded',
       Accept: 'application/json',
+      'User-Agent': this.getUserAgent(),
     };
 
     if (this.bearerToken !== undefined)
       headers.Authorization = `Bearer ${this.bearerToken}`;
 
-    const response = await request(
+    const response = await requestWithBackoff(
       path,
       {
         method: 'POST',
@@ -212,16 +268,44 @@ export class ZaptecApi {
     PageIndex?: number;
     IncludeDisabled?: boolean;
     Exclude?: string[];
-  }) {
-    const { data, response } = await this.get<PagedData<SessionListModel>>(
-      `/api/chargehistory?${querystring.stringify(params)}`,
-      {},
-    );
+  }): Promise<SessionListModel[]> {
+    let allData: SessionListModel[] = [];
+    let currentPage = 0;
+    const pageSize = params.PageSize || 50;
+    let totalPages = 1;
 
-    if (response.statusCode !== 200)
-      throw new Error(`Unexpected response statusCode ${response.statusCode}`);
+    while (currentPage < totalPages) {
+      const { data, response } = await this.get<PagedData<SessionListModel>>(
+        `/api/chargehistory?${querystring.stringify({
+          ...params,
+          PageSize: pageSize,
+          PageIndex: currentPage,
+        })}`,
+        {},
+      );
 
-    return data;
+      if (response.statusCode !== 200) {
+        throw new Error(
+          `Unexpected response statusCode ${response.statusCode}`,
+        );
+      }
+
+      const pageData = data.Data ?? [];
+      if (!Array.isArray(pageData)) {
+        throw new Error(
+          `Expected Data to be an array, but got ${typeof pageData}`,
+        );
+      }
+
+      allData = allData.concat(pageData);
+
+      totalPages = data.Pages ?? 0;
+      if (currentPage >= totalPages - 1) break;
+
+      currentPage += 1;
+    }
+
+    return allData;
   }
 
   // -------------------------- //
@@ -299,12 +383,11 @@ export class ZaptecApi {
   }
 
   public async lockCharger(chargerId: string, lock: boolean): Promise<void> {
-    
     const { data, response } = await this.post<TokenResponse>(
       `/api/chargers/${chargerId}/localSettings`,
       {
-        "Cable": {
-          "PermanentLock": lock
+        Cable: {
+          PermanentLock: lock,
         },
       },
     );
@@ -433,5 +516,13 @@ export class ZaptecApi {
       throw new Error(`Unexpected response statusCode ${response.statusCode}`);
 
     return data;
+  }
+
+  // -------------------------- //
+  //  User Agent
+  // -------------------------- //
+
+  private getUserAgent(): string {
+    return `AthomHomey/com.zaptec/${this.version} (https://github.com/PatrickE94/com.zaptec)`;
   }
 }


### PR DESCRIPTION
Hello, Zaptec devs are here!

We see some issues with the current implementation of the app from our side (for example scheduled fetch of the data is failing).

We would like to help with a reliability of the plugin for Homey users, and to do so, the following changes are proposed:

* Random jitter to cron jobs to reduce simultaneous endpoint querying — this will help with 4xx and 5xx errors users are experiencing (at scale it looks like mini DoS and will be rate limited heavily).
* Implemented paging support for charging history API calls — this will help to get better throughput at scale.
* Introduced backoff mechanism for handling 429 Too Many Requests responses.
* Added custom User-Agent header to API requests for better tracking — in the future empty user agent may prevent Homey users from using the API.
* Refactored device initialization to include app version.


These changes enhance API robustness and prevent potential overloading while ensuring compatibility with paginated responses. We hope that these changes will be beneficial for all Homey users and will improve the overall experience with the Zaptec app.


We deeply appreciate the time and expertise that go into maintaining and improving the Homey plugin, and we're excited to do a small contribution to its continued success.