### PR TITLE
49 rename meter power this year

### DIFF
--- a/.homeycompose/drivers/templates/defaults.json
+++ b/.homeycompose/drivers/templates/defaults.json
@@ -11,7 +11,10 @@
   "connectivity": [
     "cloud"
   ],
-  "class": "other",
+  "class": "evcharger",
+  "energy": {
+    "cumulative": true
+  },
   "pair": [
     {
       "id": "login_credentials",

--- a/app.json
+++ b/app.json
@@ -1188,7 +1188,7 @@
       },
       "capabilities": [
         "meter_power.current_session",
-        "meter_power.this_year",
+        "meter_power",
         "meter_power.last_session",
         "measure_power",
         "charging_button",
@@ -1212,7 +1212,7 @@
             "no": "Energibruk ladeøkt"
           }
         },
-        "meter_power.this_year": {
+        "meter_power": {
           "title": {
             "en": "Energy this year",
             "no": "Energiforbruk i år"
@@ -1385,7 +1385,7 @@
       },
       "capabilities": [
         "meter_power.current_session",
-        "meter_power.this_year",
+        "meter_power",
         "meter_power.last_session",
         "measure_power",
         "charging_button",
@@ -1410,7 +1410,7 @@
             "no": "Energibruk ladeøkt"
           }
         },
-        "meter_power.this_year": {
+        "meter_power": {
           "title": {
             "en": "Energy this year",
             "no": "Energiforbruk i år"
@@ -1595,7 +1595,7 @@
       },
       "capabilities": [
         "meter_power.current_session",
-        "meter_power.this_year",
+        "meter_power",
         "meter_power.last_session",
         "measure_power",
         "charging_button",
@@ -1620,7 +1620,7 @@
             "no": "Energibruk ladeøkt"
           }
         },
-        "meter_power.this_year": {
+        "meter_power": {
           "title": {
             "en": "Energy this year",
             "no": "Energiforbruk i år"

--- a/app.json
+++ b/app.json
@@ -1157,6 +1157,9 @@
         "cloud"
       ],
       "class": "evcharger",
+      "energy": {
+        "cumulative": true
+      },
       "pair": [
         {
           "id": "login_credentials",
@@ -1351,6 +1354,9 @@
         "cloud"
       ],
       "class": "evcharger",
+      "energy": {
+        "cumulative": true
+      },
       "pair": [
         {
           "id": "login_credentials",
@@ -1558,6 +1564,9 @@
         "cloud"
       ],
       "class": "evcharger",
+      "energy": {
+        "cumulative": true
+      },
       "pair": [
         {
           "id": "login_credentials",

--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -34,6 +34,7 @@ export class GoCharger extends Homey.Device {
     await this.migrateClass();
     await this.migrateCapabilities();
     await this.migrateSettings();
+    await this.migrateEnergy();
     this.registerCapabilityListeners();
 
     this.cronTasks.push(
@@ -67,6 +68,17 @@ export class GoCharger extends Homey.Device {
         })
         .catch((e) => {
           this.logToDebug(`Failed to set device class: ${e}`);
+        });
+    }
+  }
+
+  private async migrateEnergy() {
+    const energyConfig = this.getEnergy();
+      if (energyConfig.cumulative !== true) {
+        this.setEnergy({
+          cumulative: true
+        }).catch((e) => {
+          this.logToDebug(`Failed to migrate energy: ${e}`);
         });
     }
   }

--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -132,27 +132,24 @@ export class GoCharger extends Homey.Device {
    * This avoids having to re-add the device when modifying capabilities.
    */
   private async migrateCapabilities() {
-    const remove = [
-      'available_installation_current.phase1',
-      'available_installation_current.phase2',
-      'available_installation_current.phase3',
-      'meter_power',
-      'onoff',
+    const remove = ['available_installation_current.phase1','available_installation_current.phase2','available_installation_current.phase3','meter_power.this_year','onoff',
+      'meter_power.current_session','meter_power','meter_power.last_session','measure_power','alarm_generic.car_connected','measure_humidity','measure_temperature'
     ];
 
     for (const cap of remove)
       if (this.hasCapability(cap)) await this.removeCapability(cap);
 
     const add = [
-      'available_installation_current',
-      'meter_power.last_session',
-      'meter_power.this_year',
+      'measure_power',
       'meter_power.current_session',
+      'meter_power',
+      'meter_power.last_session',
       'alarm_generic.car_connected',
+      'measure_humidity',
       'charging_button', // replaces onoff
       'measure_temperature',
-      'measure_humidity',
       'cable_permanent_lock',
+      'available_installation_current',
     ];
 
     for (const cap of add)
@@ -344,7 +341,7 @@ export class GoCharger extends Homey.Device {
       .then((charges) => {
         const yearlyEnergy =
           charges?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
-        return this.setCapabilityValue('meter_power.this_year', yearlyEnergy);
+        return this.setCapabilityValue('meter_power', yearlyEnergy);
       })
       .then(() => {
         this.logToDebug(`Got yearly power history`);
@@ -377,24 +374,30 @@ export class GoCharger extends Homey.Device {
         break;
 
       case ApolloDeviceObservation.CurrentPhase1:
-        await this.setCapabilityValue(
-          'measure_current.phase1',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase1')) {
+          await this.setCapabilityValue(
+            'measure_current.phase1',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case ApolloDeviceObservation.CurrentPhase2:
-        await this.setCapabilityValue(
-          'measure_current.phase2',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase2')) {
+          await this.setCapabilityValue(
+            'measure_current.phase2',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case ApolloDeviceObservation.CurrentPhase3:
-        await this.setCapabilityValue(
-          'measure_current.phase3',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase3')) {
+          await this.setCapabilityValue(
+            'measure_current.phase3',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case ApolloDeviceObservation.VoltagePhase1:

--- a/drivers/go/driver.compose.json
+++ b/drivers/go/driver.compose.json
@@ -8,7 +8,7 @@
   "class": "evcharger",
   "capabilities": [
     "meter_power.current_session",
-    "meter_power.this_year",
+    "meter_power",
     "meter_power.last_session",
     "measure_power",
     "charging_button",
@@ -32,7 +32,7 @@
         "no": "Energibruk ladeøkt"
       }
     },
-    "meter_power.this_year": {
+    "meter_power": {
       "title": {
         "en": "Energy this year",
         "no": "Energiforbruk i år"

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -132,15 +132,22 @@ export class HomeCharger extends Homey.Device {
    * This avoids having to re-add the device when modifying capabilities.
    */
   private async migrateCapabilities() {
-    const remove: string[] = ['measure_temperature'];
+    const remove: string[] = ['measure_temperature','meter_power.this_year',
+      'meter_power.current_session','meter_power','meter_power.last_session','measure_power','alarm_generic.car_connected','measure_humidity','measure_temperature.sensor1','measure_temperature.sensor2'
+    ];
 
     for (const cap of remove)
       if (this.hasCapability(cap)) await this.removeCapability(cap);
 
     const add = [
+      'measure_power',
+      'meter_power.current_session',
+      'meter_power',
+      'meter_power.last_session',
+      'alarm_generic.car_connected',
+      'measure_humidity',
       'measure_temperature.sensor1',
       'measure_temperature.sensor2',
-      'measure_humidity',
       'cable_permanent_lock',
     ];
 
@@ -333,7 +340,7 @@ export class HomeCharger extends Homey.Device {
       .then((charges) => {
         const yearlyEnergy =
           charges?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
-        return this.setCapabilityValue('meter_power.this_year', yearlyEnergy);
+        return this.setCapabilityValue('meter_power', yearlyEnergy);
       })
       .then(() => {
         this.logToDebug(`Got yearly power history`);
@@ -366,24 +373,30 @@ export class HomeCharger extends Homey.Device {
         break;
 
       case SmartDeviceObservation.CurrentPhase1:
-        await this.setCapabilityValue(
-          'measure_current.phase1',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase1')) {
+          await this.setCapabilityValue(
+            'measure_current.phase1',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case SmartDeviceObservation.CurrentPhase2:
-        await this.setCapabilityValue(
-          'measure_current.phase2',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase2')) {
+          await this.setCapabilityValue(
+            'measure_current.phase2',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case SmartDeviceObservation.CurrentPhase3:
-        await this.setCapabilityValue(
-          'measure_current.phase3',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase3')) {
+          await this.setCapabilityValue(
+            'measure_current.phase3',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case SmartDeviceObservation.VoltagePhase1:

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -34,6 +34,7 @@ export class HomeCharger extends Homey.Device {
     await this.migrateClass();
     await this.migrateCapabilities();
     await this.migrateSettings();
+    await this.migrateEnergy();
     this.registerCapabilityListeners();
 
     this.cronTasks.push(
@@ -67,6 +68,17 @@ export class HomeCharger extends Homey.Device {
         })
         .catch((e) => {
           this.logToDebug(`Failed to set device class: ${e}`);
+        });
+    }
+  }
+
+  private async migrateEnergy() {
+    const energyConfig = this.getEnergy();
+      if (energyConfig.cumulative !== true) {
+        this.setEnergy({
+          cumulative: true
+        }).catch((e) => {
+          this.logToDebug(`Failed to migrate energy: ${e}`);
         });
     }
   }

--- a/drivers/home/driver.compose.json
+++ b/drivers/home/driver.compose.json
@@ -8,7 +8,7 @@
   "class": "evcharger",
   "capabilities": [
     "meter_power.current_session",
-    "meter_power.this_year",
+    "meter_power",
     "meter_power.last_session",
     "measure_power",
     "charging_button",
@@ -33,7 +33,7 @@
         "no": "Energibruk ladeøkt"
       }
     },
-    "meter_power.this_year": {
+    "meter_power": {
       "title": {
         "en": "Energy this year",
         "no": "Energiforbruk i år"

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -132,15 +132,22 @@ export class ProCharger extends Homey.Device {
    * This avoids having to re-add the device when modifying capabilities.
    */
   private async migrateCapabilities() {
-    const remove: string[] = ['measure_temperature'];
+    const remove: string[] = ['meter_power.this_year','measure_temperature',
+      'meter_power.current_session','meter_power','meter_power.last_session','measure_power','alarm_generic.car_connected','measure_humidity','measure_temperature.sensor1','measure_temperature.sensor2'
+    ];
 
     for (const cap of remove)
       if (this.hasCapability(cap)) await this.removeCapability(cap);
 
-    const add = [
+    const add = [   
+      'measure_power',
+      'meter_power.current_session',
+      'meter_power',
+      'meter_power.last_session',
+      'alarm_generic.car_connected',
+      'measure_humidity',
       'measure_temperature.sensor1',
       'measure_temperature.sensor2',
-      'measure_humidity',
       'cable_permanent_lock',
     ];
 
@@ -334,7 +341,7 @@ export class ProCharger extends Homey.Device {
       .then((charges) => {
         const yearlyEnergy =
           charges?.reduce((sum, charge) => sum + charge.Energy, 0) || 0;
-        return this.setCapabilityValue('meter_power.this_year', yearlyEnergy);
+        return this.setCapabilityValue('meter_power', yearlyEnergy);
       })
       .then(() => {
         this.logToDebug(`Got yearly power history`);
@@ -367,24 +374,30 @@ export class ProCharger extends Homey.Device {
         break;
 
       case SmartDeviceObservation.CurrentPhase1:
-        await this.setCapabilityValue(
-          'measure_current.phase1',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase1')) {
+          await this.setCapabilityValue(
+            'measure_current.phase1',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case SmartDeviceObservation.CurrentPhase2:
-        await this.setCapabilityValue(
-          'measure_current.phase2',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase2')) {
+          await this.setCapabilityValue(
+            'measure_current.phase2',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case SmartDeviceObservation.CurrentPhase3:
-        await this.setCapabilityValue(
-          'measure_current.phase3',
-          Number(state.ValueAsString),
-        );
+        if (this.hasCapability('measure_current.phase3')) {
+          await this.setCapabilityValue(
+            'measure_current.phase3',
+            Number(state.ValueAsString),
+          );
+        }
         break;
 
       case SmartDeviceObservation.VoltagePhase1:

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -34,6 +34,7 @@ export class ProCharger extends Homey.Device {
     await this.migrateClass();
     await this.migrateCapabilities();
     await this.migrateSettings();
+    await this.migrateEnergy();
     this.registerCapabilityListeners();
 
     this.cronTasks.push(
@@ -67,6 +68,17 @@ export class ProCharger extends Homey.Device {
         })
         .catch((e) => {
           this.logToDebug(`Failed to set device class: ${e}`);
+        });
+    }
+  }
+
+  private async migrateEnergy() {
+    const energyConfig = this.getEnergy();
+      if (energyConfig.cumulative !== true) {
+        this.setEnergy({
+          cumulative: true
+        }).catch((e) => {
+          this.logToDebug(`Failed to migrate energy: ${e}`);
         });
     }
   }

--- a/drivers/pro/driver.compose.json
+++ b/drivers/pro/driver.compose.json
@@ -8,7 +8,7 @@
   "class": "evcharger",
   "capabilities": [
     "meter_power.current_session",
-    "meter_power.this_year",
+    "meter_power",
     "meter_power.last_session",
     "measure_power",
     "charging_button",
@@ -33,7 +33,7 @@
         "no": "Energibruk ladeøkt"
       }
     },
-    "meter_power.this_year": {
+    "meter_power": {
       "title": {
         "en": "Energy this year",
         "no": "Energiforbruk i år"


### PR DESCRIPTION
Fixes #49 

Renames the capability meter_power.this_year to meter_power to support the new energy tab.
Adds cummulative energy setting to defaults + migration script for all devices
Also fix the ordering of capabilities.