### PR TITLE
48 support for signedmetervalue

### DIFF
--- a/app.json
+++ b/app.json
@@ -1317,6 +1317,15 @@
                 "no": "Enhets ID"
               },
               "value": ""
+            },
+            {
+              "id": "signedMeterValue",
+              "type": "label",
+              "label": {
+                "en": "Signed Meter Value",
+                "no": "Målerstand"
+              },
+              "value": ""
             }
           ]
         },
@@ -1524,7 +1533,16 @@
               "type": "label",
               "label": {
                 "en": "Device ID",
-                "no": "ID"
+                "no": "Enhets ID"
+              },
+              "value": ""
+            },
+            {
+              "id": "signedMeterValue",
+              "type": "label",
+              "label": {
+                "en": "Signed Meter Value",
+                "no": "Målerstand"
               },
               "value": ""
             }
@@ -1735,6 +1753,15 @@
               "label": {
                 "en": "Device ID",
                 "no": "Enhets ID"
+              },
+              "value": ""
+            },
+            {
+              "id": "signedMeterValue",
+              "type": "label",
+              "label": {
+                "en": "Signed Meter Value",
+                "no": "Målerstand"
               },
               "value": ""
             }

--- a/app.json
+++ b/app.json
@@ -1203,7 +1203,8 @@
         "measure_voltage.phase2",
         "measure_voltage.phase3",
         "measure_humidity",
-        "measure_temperature"
+        "measure_temperature",
+        "meter_power.signed_meter_value"
       ],
       "capabilitiesOptions": {
         "meter_power.current_session": {
@@ -1271,6 +1272,13 @@
             "en": "Car connected",
             "no": "Bil tilkoblet"
           }
+        },
+        "meter_power.signed_meter_value": {
+          "title": {
+            "en": "Signed meter value",
+            "no": "Målerstand"
+          },
+          "uiComponent": "none"
         }
       },
       "id": "go",
@@ -1410,7 +1418,8 @@
         "measure_voltage.phase3",
         "measure_humidity",
         "measure_temperature.sensor1",
-        "measure_temperature.sensor2"
+        "measure_temperature.sensor2",
+        "meter_power.signed_meter_value"
       ],
       "capabilitiesOptions": {
         "meter_power.current_session": {
@@ -1490,6 +1499,13 @@
             "en": "Temperature Sensor 2",
             "no": "Temperatur sensor 2"
           }
+        },
+        "meter_power.signed_meter_value": {
+          "title": {
+            "en": "Signed meter value",
+            "no": "Målerstand"
+          },
+          "uiComponent": "none"
         }
       },
       "id": "home",
@@ -1629,7 +1645,8 @@
         "measure_voltage.phase3",
         "measure_humidity",
         "measure_temperature.sensor1",
-        "measure_temperature.sensor2"
+        "measure_temperature.sensor2",
+        "meter_power.signed_meter_value"
       ],
       "capabilitiesOptions": {
         "meter_power.current_session": {
@@ -1709,6 +1726,13 @@
             "en": "Temperature Sensor 2",
             "no": "Temperatur sensor 2"
           }
+        },
+        "meter_power.signed_meter_value": {
+          "title": {
+            "en": "Signed meter value",
+            "no": "Målerstand"
+          },
+          "uiComponent": "none"
         }
       },
       "id": "pro",

--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -474,6 +474,10 @@ export class GoCharger extends Homey.Device {
         );
         break;
 
+      case ApolloDeviceObservation.SignedMeterValue:
+        if (state.ValueAsString) await this.onSignedMeterValue(state.ValueAsString);
+        break;
+
       default:
         break;
     }
@@ -617,6 +621,37 @@ export class GoCharger extends Homey.Device {
       );
     } catch (e) {
       this.logToDebug(`onLastSession fail: ${e}`);
+    }
+  }
+
+  protected async onSignedMeterValue(data: string) {
+    try {
+      const jsonStr = data.replace('OCMF|', '');
+      const ocmf: {
+        FV: string;
+        GI: string;
+        GS: string;
+        GV: string;
+        PG: string;
+        MF: string;
+        RD: {
+          RV: string;
+        }[];
+      } = JSON.parse(jsonStr);
+      
+      const rv = ocmf.RD?.[0]?.RV;
+      if (rv !== undefined) {
+        const num = Number(rv);
+        const formatted = Number.isInteger(num) ? num.toString() : num.toFixed(2);
+        this.setSettings({
+          signedMeterValue: formatted,
+        })
+        .catch((e) => {
+          this.logToDebug(`Failed to get OCMF-signed value: ${e}`);
+        });
+      }
+    } catch (e) {
+      this.logToDebug(`onSignedMeterValue fail: ${e}`);
     }
   }
 

--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -150,6 +150,7 @@ export class GoCharger extends Homey.Device {
       'measure_temperature',
       'cable_permanent_lock',
       'available_installation_current',
+      'meter_power.signed_meter_value'
     ];
 
     for (const cap of add)
@@ -645,6 +646,8 @@ export class GoCharger extends Homey.Device {
         const formatted = Number.isInteger(num) ? num.toString() : num.toFixed(2);
         this.setSettings({
           signedMeterValue: formatted,
+        }).then(() => {
+          this.setCapabilityValue('meter_power.signed_meter_value', rv);
         })
         .catch((e) => {
           this.logToDebug(`Failed to get OCMF-signed value: ${e}`);

--- a/drivers/go/driver.compose.json
+++ b/drivers/go/driver.compose.json
@@ -23,7 +23,8 @@
     "measure_voltage.phase2",
     "measure_voltage.phase3",
     "measure_humidity",
-    "measure_temperature"
+    "measure_temperature",
+    "meter_power.signed_meter_value"
   ],
   "capabilitiesOptions": {
     "meter_power.current_session": {
@@ -91,6 +92,13 @@
         "en": "Car connected",
         "no": "Bil tilkoblet"
       }
+    },
+    "meter_power.signed_meter_value": {
+      "title": {
+        "en": "Signed meter value",
+        "no": "Målerstand"
+      },
+      "uiComponent": "none"
     }
   }
 }

--- a/drivers/go/driver.settings.compose.json
+++ b/drivers/go/driver.settings.compose.json
@@ -41,6 +41,15 @@
                     "no": "Enhets ID"
                 },
                 "value": ""
+            },
+            {
+                "id": "signedMeterValue",
+                "type": "label",
+                "label": {
+                    "en": "Signed Meter Value",
+                    "no": "Målerstand"
+                },
+                "value": ""
             }
         ]
     },

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -148,7 +148,8 @@ export class HomeCharger extends Homey.Device {
       'measure_humidity',
       'measure_temperature.sensor1',
       'measure_temperature.sensor2',
-      'cable_permanent_lock',
+      'cable_permanent_lock', 
+      'meter_power.signed_meter_value'
     ];
 
     for (const cap of add)
@@ -651,6 +652,8 @@ export class HomeCharger extends Homey.Device {
         const formatted = Number.isInteger(num) ? num.toString() : num.toFixed(2);
         this.setSettings({
           signedMeterValue: formatted,
+        }).then(() => {
+          this.setCapabilityValue('meter_power.signed_meter_value', rv);
         })
         .catch((e) => {
           this.logToDebug(`Failed to get OCMF-signed value: ${e}`);

--- a/drivers/home/driver.compose.json
+++ b/drivers/home/driver.compose.json
@@ -24,7 +24,8 @@
     "measure_voltage.phase3",
     "measure_humidity",
     "measure_temperature.sensor1",
-    "measure_temperature.sensor2"
+    "measure_temperature.sensor2",
+    "meter_power.signed_meter_value"
   ],
   "capabilitiesOptions": {
     "meter_power.current_session": {
@@ -104,6 +105,13 @@
         "en": "Temperature Sensor 2",
         "no": "Temperatur sensor 2"
       }
+    },
+    "meter_power.signed_meter_value": {
+      "title": {
+        "en": "Signed meter value",
+        "no": "Målerstand"
+      },
+      "uiComponent": "none"
     }
   }
 }

--- a/drivers/home/driver.settings.compose.json
+++ b/drivers/home/driver.settings.compose.json
@@ -38,7 +38,15 @@
                 "type": "label",
                 "label": { 
                     "en": "Device ID",
-                    "no": "ID"
+                    "no": "Enhets ID"
+                },
+                "value": ""
+            },            {
+                "id": "signedMeterValue",
+                "type": "label",
+                "label": {
+                    "en": "Signed Meter Value",
+                    "no": "Målerstand"
                 },
                 "value": ""
             }

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -149,6 +149,7 @@ export class ProCharger extends Homey.Device {
       'measure_temperature.sensor1',
       'measure_temperature.sensor2',
       'cable_permanent_lock',
+      'meter_power.signed_meter_value'
     ];
 
     for (const cap of add)
@@ -652,6 +653,8 @@ export class ProCharger extends Homey.Device {
         const formatted = Number.isInteger(num) ? num.toString() : num.toFixed(2);
         this.setSettings({
           signedMeterValue: formatted,
+        }).then(() => {
+          this.setCapabilityValue('meter_power.signed_meter_value', rv);
         })
         .catch((e) => {
           this.logToDebug(`Failed to get OCMF-signed value: ${e}`);

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -481,6 +481,10 @@ export class ProCharger extends Homey.Device {
         );
         break;
 
+      case SmartDeviceObservation.SignedMeterValue:
+        if (state.ValueAsString) await this.onSignedMeterValue(state.ValueAsString);
+        break;
+
       default:
         break;
     }
@@ -624,6 +628,37 @@ export class ProCharger extends Homey.Device {
       );
     } catch (e) {
       this.logToDebug(`onLastSession fail: ${e}`);
+    }
+  }
+
+  protected async onSignedMeterValue(data: string) {
+    try {
+      const jsonStr = data.replace('OCMF|', '');
+      const ocmf: {
+        FV: string;
+        GI: string;
+        GS: string;
+        GV: string;
+        PG: string;
+        MF: string;
+        RD: {
+          RV: string;
+        }[];
+      } = JSON.parse(jsonStr);
+      
+      const rv = ocmf.RD?.[0]?.RV;
+      if (rv !== undefined) {
+        const num = Number(rv);
+        const formatted = Number.isInteger(num) ? num.toString() : num.toFixed(2);
+        this.setSettings({
+          signedMeterValue: formatted,
+        })
+        .catch((e) => {
+          this.logToDebug(`Failed to get OCMF-signed value: ${e}`);
+        });
+      }
+    } catch (e) {
+      this.logToDebug(`onSignedMeterValue fail: ${e}`);
     }
   }
 

--- a/drivers/pro/driver.compose.json
+++ b/drivers/pro/driver.compose.json
@@ -24,7 +24,8 @@
     "measure_voltage.phase3",
     "measure_humidity",
     "measure_temperature.sensor1",
-    "measure_temperature.sensor2"
+    "measure_temperature.sensor2",
+    "meter_power.signed_meter_value"
   ],
   "capabilitiesOptions": {
     "meter_power.current_session": {
@@ -104,6 +105,13 @@
         "en": "Temperature Sensor 2",
         "no": "Temperatur sensor 2"
       }
+    },
+    "meter_power.signed_meter_value": {
+      "title": {
+        "en": "Signed meter value",
+        "no": "Målerstand"
+      },
+      "uiComponent": "none"
     }
   }
 }

--- a/drivers/pro/driver.settings.compose.json
+++ b/drivers/pro/driver.settings.compose.json
@@ -41,6 +41,15 @@
                     "no": "Enhets ID"
                 },
                 "value": ""
+            },
+            {
+                "id": "signedMeterValue",
+                "type": "label",
+                "label": {
+                    "en": "Signed Meter Value",
+                    "no": "Målerstand"
+                },
+                "value": ""
             }
         ]
     },


### PR DESCRIPTION
Fixes #48 

Adds SignedMeterValue to advanced settings and as a invisible capability to be used as tag in flows.
Migration script added