### PR TITLE
Fixed initial state of cable connected capability

### DIFF
--- a/drivers/go/device.ts
+++ b/drivers/go/device.ts
@@ -539,9 +539,6 @@ export class GoCharger extends Homey.Device {
       this.getCapabilityValue('charge_mode'),
     );
 
-    // If no mode change occurs, don't run the triggers
-    if (previousMode === newMode) return;
-
     const previouslyDisconnected =
       previousMode === ChargerOperationMode.Unknown ||
       previousMode === ChargerOperationMode.Disconnected;
@@ -559,6 +556,9 @@ export class GoCharger extends Homey.Device {
       'alarm_generic.car_connected',
       newModeConnected,
     );
+
+    // If no mode change occurs, don't run the triggers
+    if (previousMode === newMode) return;
 
     this.logToDebug(`Charger operation mode update: ${previousMode} to ${newMode}`);
 

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -545,9 +545,6 @@ export class HomeCharger extends Homey.Device {
       this.getCapabilityValue('charge_mode'),
     );
 
-    // If no mode change occurs, don't run the triggers
-    if (previousMode === newMode) return;
-
     const previouslyDisconnected =
       previousMode === ChargerOperationMode.Unknown ||
       previousMode === ChargerOperationMode.Disconnected;
@@ -565,6 +562,9 @@ export class HomeCharger extends Homey.Device {
       'alarm_generic.car_connected',
       newModeConnected,
     );
+
+    // If no mode change occurs, don't run the triggers
+    if (previousMode === newMode) return;    
 
     this.logToDebug(`Charger operation mode update: ${previousMode} to ${newMode}`);
 

--- a/drivers/pro/device.ts
+++ b/drivers/pro/device.ts
@@ -546,9 +546,6 @@ export class ProCharger extends Homey.Device {
       this.getCapabilityValue('charge_mode'),
     );
 
-    // If no mode change occurs, don't run the triggers
-    if (previousMode === newMode) return;
-
     const previouslyDisconnected =
       previousMode === ChargerOperationMode.Unknown ||
       previousMode === ChargerOperationMode.Disconnected;
@@ -566,6 +563,9 @@ export class ProCharger extends Homey.Device {
       'alarm_generic.car_connected',
       newModeConnected,
     );
+
+    // If no mode change occurs, don't run the triggers
+    if (previousMode === newMode) return;
 
     this.logToDebug(`Charger operation mode update: ${previousMode} to ${newMode}`);
 


### PR DESCRIPTION
The capability is only set if charger state is changed since last time. When restarting the app this will not happen. 
Moved the override to prevent trigger when state is not changed, to after setting the capability.
This will fix the bug, but not trigger anything.