### PR TITLE
Given correct insights title for car_connected

### DIFF
--- a/app.json
+++ b/app.json
@@ -1633,6 +1633,14 @@
           "title": {
             "en": "Car connected",
             "no": "Bil tilkoblet"
+          },
+          "insightsTitleTrue": {
+            "en": "Car connected",
+            "no": "Bil koblet til lader"
+          },
+          "insightsTitleFalse": {
+            "en": "Car disconnected",
+            "no": "Bil koblet fra lader"
           }
         },
         "meter_power.signed_meter_value": {
@@ -1856,6 +1864,14 @@
           "title": {
             "en": "Car connected",
             "no": "Bil tilkoblet"
+          },
+          "insightsTitleTrue": {
+            "en": "Car connected",
+            "no": "Bil koblet til lader"
+          },
+          "insightsTitleFalse": {
+            "en": "Car disconnected",
+            "no": "Bil koblet fra lader"
           }
         },
         "meter_power.signed_meter_value": {
@@ -2080,6 +2096,14 @@
           "title": {
             "en": "Car connected",
             "no": "Bil koblet til"
+          },
+          "insightsTitleTrue": {
+            "en": "Car connected",
+            "no": "Bil koblet til lader"
+          },
+          "insightsTitleFalse": {
+            "en": "Car disconnected",
+            "no": "Bil koblet fra lader"
           }
         },
         "measure_temperature.sensor1": {
@@ -2316,6 +2340,14 @@
           "title": {
             "en": "Car connected",
             "no": "Bil tilkoblet"
+          },
+          "insightsTitleTrue": {
+            "en": "Car connected",
+            "no": "Bil koblet til lader"
+          },
+          "insightsTitleFalse": {
+            "en": "Car disconnected",
+            "no": "Bil koblet fra lader"
           }
         },
         "measure_temperature.sensor1": {

--- a/drivers/go/driver.compose.json
+++ b/drivers/go/driver.compose.json
@@ -93,6 +93,14 @@
       "title": {
         "en": "Car connected",
         "no": "Bil tilkoblet"
+      },
+      "insightsTitleTrue": {
+        "en": "Car connected",
+        "no": "Bil koblet til lader"
+      },
+      "insightsTitleFalse": {
+        "en": "Car disconnected",
+        "no": "Bil koblet fra lader"
       }
     },
     "meter_power.signed_meter_value": {

--- a/drivers/go2/driver.compose.json
+++ b/drivers/go2/driver.compose.json
@@ -93,6 +93,14 @@
       "title": {
         "en": "Car connected",
         "no": "Bil tilkoblet"
+      },
+      "insightsTitleTrue": {
+        "en": "Car connected",
+        "no": "Bil koblet til lader"
+      },
+      "insightsTitleFalse": {
+        "en": "Car disconnected",
+        "no": "Bil koblet fra lader"
       }
     },
     "meter_power.signed_meter_value": {

--- a/drivers/home/driver.compose.json
+++ b/drivers/home/driver.compose.json
@@ -94,6 +94,14 @@
       "title": {
         "en": "Car connected",
         "no": "Bil koblet til"
+      },
+      "insightsTitleTrue": {
+        "en": "Car connected",
+        "no": "Bil koblet til lader"
+      },
+      "insightsTitleFalse": {
+        "en": "Car disconnected",
+        "no": "Bil koblet fra lader"
       }
     },
     "measure_temperature.sensor1": {

--- a/drivers/pro/driver.compose.json
+++ b/drivers/pro/driver.compose.json
@@ -94,6 +94,14 @@
       "title": {
         "en": "Car connected",
         "no": "Bil tilkoblet"
+      },
+      "insightsTitleTrue": {
+        "en": "Car connected",
+        "no": "Bil koblet til lader"
+      },
+      "insightsTitleFalse": {
+        "en": "Car disconnected",
+        "no": "Bil koblet fra lader"
       }
     },
     "measure_temperature.sensor1": {


### PR DESCRIPTION
The `alarm_generic` capability used for `car_connected` should have a better description, because it shows "Generic alarm activated" in the log/insights panel.