### PR TITLE
fix: make token type comparison case-insensitive in authentication

### DIFF
--- a/lib/zaptec/api.ts
+++ b/lib/zaptec/api.ts
@@ -342,9 +342,9 @@ export class ZaptecApi {
     );
 
     if (response.statusCode === 200) {
-      if (data.token_type !== 'Bearer') {
+      if (data.token_type.toLowerCase() !== 'bearer') {
         throw new Error(
-          `Invalid token type received ${data.token_type}, expected ${data.token_type}`,
+          `Invalid token type received ${data.token_type}, expected Bearer`,
         );
       }
 


### PR DESCRIPTION
The Zaptec API returns token_type as "bearer" (lowercase), but the code was checking for exactly "Bearer" (uppercase), causing authentication to fail. Changed the comparison to be case-insensitive using toLowerCase(). This is likely due to an API update. We now ignore casing in our comparison.

Also fixed the error message which was incorrectly showing data.token_type twice instead of displaying the expected value "Bearer".