### PR TITLE
fix: Add missing scope to authentication

### DIFF
--- a/lib/zaptec/api.ts
+++ b/lib/zaptec/api.ts
@@ -338,6 +338,7 @@ export class ZaptecApi {
         grant_type: 'password',
         username,
         password,
+        scope: 'offline_access',
       }),
     );
 


### PR DESCRIPTION
Zaptec has migrated to a new authentication system. It requires setting scope to offline_access. This is likely a miss in the documentation since it's not required there.

The fix was provided by Zaptec directly. So many thanks.